### PR TITLE
docs(react-components): add import statements to examples

### DIFF
--- a/apps/react-kits-doc/stories/ui-components/button/button/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/button/button/overview/color.stories.tsx
@@ -11,9 +11,7 @@ export const Color: StoryObj<typeof Button> = {
       },
     },
     cckAddon: {
-      renderConditions: [
-        renderWithThemeProp('color'), renderWithPageTab('Overview')
-      ],
+      renderConditions: [renderWithThemeProp('color'), renderWithPageTab('Overview')],
       singleControls: ['type'],
       source: [
         {

--- a/apps/react-kits-doc/stories/ui-components/button/button/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/button/button/overview/size.stories.tsx
@@ -34,7 +34,6 @@ export const Size: StoryObj<typeof Button> = {
                 <% }) %>
               </>
 
-              <>
             );
           }
           `,

--- a/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/color.stories.tsx
@@ -19,7 +19,7 @@ export const Color: StoryObj<typeof IconButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { IconButton } from "@cocokits/react-components";
+          import { IconButton , SvgIcon } from "@cocokits/react-components";
 
           export const MyComponent = () => {
             return (

--- a/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/default.stories.tsx
@@ -18,7 +18,7 @@ export const Default: StoryObj<typeof IconButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { IconButton, SvgIcon} from '@cocokits/react-components';
+          import { IconButton, SvgIcon } from '@cocokits/react-components';
 
           export const MyComponent = () => {
             return (

--- a/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/size.stories.tsx
@@ -20,7 +20,7 @@ export const Size: StoryObj<typeof IconButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { IconButton } from "@cocokits/react-components";
+          import { IconButton , SvgIcon } from "@cocokits/react-components";
 
           export const MyComponent = () => {
             return (

--- a/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/button/icon-button/overview/type.stories.tsx
@@ -8,7 +8,8 @@ export const Type: StoryObj<typeof IconButton> = {
   parameters: {
     docs: {
       description: {
-        story: 'Displays variations in appearance and functionality, demonstrating how different types can be used to create unique button styles.',
+        story:
+          'Displays variations in appearance and functionality, demonstrating how different types can be used to create unique button styles.',
       },
     },
     cckAddon: {
@@ -18,7 +19,7 @@ export const Type: StoryObj<typeof IconButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { IconButton } from "@cocokits/react-components";
+          import { IconButton , SvgIcon } from "@cocokits/react-components";
 
           export const MyComponent = () => {
             return (
@@ -40,11 +41,11 @@ export const Type: StoryObj<typeof IconButton> = {
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
+      {args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
         <IconButton key={index} type={type}>
           <SvgIcon icon={args.cckIcons.heartFill} />
         </IconButton>
-      )) }
+      ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/checkbox/checkbox/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/checkbox/checkbox/overview/default.stories.tsx
@@ -18,17 +18,24 @@ export const Default: StoryObj<typeof Checkbox> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <Checkbox
-              <% if (typeof type !== 'undefined') { %> type="<%= type %>" <% } %>
-              <% if (typeof size !== 'undefined') { %> size="<%= size %>" <% } %>
-              <% if (typeof color !== 'undefined') { %> color="<%= color %>" <% } %>
-              <% if (indeterminate) { %> indeterminate <% } %>
-              <% if (disabled) { %> disabled <% } %>
-              <% if (checked) { %> checked <% } %>
-              value="YOUR_VALUE"
-            >
-              <%= text %>
-            </cck-checkbox>
+           
+            import { Checkbox } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                   <Checkbox
+                      <% if (typeof type !== 'undefined') { %> type="<%= type %>" <% } %>
+                      <% if (typeof size !== 'undefined') { %> size="<%= size %>" <% } %>
+                      <% if (typeof color !== 'undefined') { %> color="<%= color %>" <% } %>
+                      <% if (indeterminate) { %> indeterminate <% } %>
+                      <% if (disabled) { %> disabled <% } %>
+                      <% if (checked) { %> checked <% } %>
+                      value="YOUR_VALUE"
+                    />
+                </>
+              );
+            }
           `,
         },
       ],
@@ -53,5 +60,5 @@ export const Default: StoryObj<typeof Checkbox> = {
       disabled={args.cckControl.disabled}>
       {args.cckControl.text}
     </Checkbox>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/divider/divider/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/divider/divider/overview/color.stories.tsx
@@ -18,13 +18,19 @@ export const Color: StoryObj<typeof Divider> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <>
-              <% themeComponentConfig.color.values.map(color => { %>
-                <Divider
-                  <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
+              import { Divider } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                 <% themeComponentConfig.color.values.map(color => { %>
+                  <Divider
+                    <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
                   color="<%= color %>"/>
-              <% }) %>
-            </>
+                   <% }) %>
+                </>
+              );
+            }
           `,
         },
       ],
@@ -34,8 +40,8 @@ export const Color: StoryObj<typeof Divider> = {
   render: (args) => (
     <>
       {args.cckControl.themeComponentConfig.color?.values.map((color, index) => (
-        <Divider key={index} type={args.cckControl.type} color={color}/>
+        <Divider key={index} type={args.cckControl.type} color={color} />
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/divider/divider/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/divider/divider/overview/default.stories.tsx
@@ -20,24 +20,25 @@ export const Default: StoryObj<DividerComponent> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <Divider
-              <% if (typeof type !== 'undefined') { %> type="<%= type %>" <% } %>
-              <% if (typeof size !== 'undefined') { %> size="<%= size %>" <% } %>
-              <% if (typeof color !== 'undefined') { %> color="<%= color %>" <% } %>
-            />
+           import { Divider } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <Divider
+                    <% if (typeof type !== 'undefined') { %> type="<%= type %>" <% } %>
+                    <% if (typeof size !== 'undefined') { %> size="<%= size %>" <% } %>
+                    <% if (typeof color !== 'undefined') { %> color="<%= color %>" <% } %>
+                  />
+                </>
+              );
+            }
           `,
         },
       ],
       hasControl: true,
-      controls: [
-        CCK_CONTROL.type(),
-        CCK_CONTROL.color(),
-        CCK_CONTROL.size(),
-        CCK_CONTROL.additional(),
-      ],
+      controls: [CCK_CONTROL.type(), CCK_CONTROL.color(), CCK_CONTROL.size(), CCK_CONTROL.additional()],
     },
   },
-  render: (args) => (
-    <Divider style={{margin: '0 auto'}} {...reactThemeArgsToTemplate(args)}/>
-  )
+  render: (args) => <Divider style={{ margin: '0 auto' }} {...reactThemeArgsToTemplate(args)} />,
 };

--- a/apps/react-kits-doc/stories/ui-components/divider/divider/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/divider/divider/overview/size.stories.tsx
@@ -19,24 +19,30 @@ export const Size: StoryObj<typeof Divider> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <>
-              <% themeComponentConfig.size.values.map(size => { %>
+            import { Divider } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                    <% themeComponentConfig.size.values.map(size => { %>
                 <Divider
                   <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
                   size="<%= size %>"/>
               <% }) %>
-            </>
+                </>
+              );
+            }
           `,
         },
       ],
-      controls: [CCK_CONTROL.type(),],
+      controls: [CCK_CONTROL.type()],
     },
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.size?.values.map((size, index) => (
-        <Divider key={index} type={args.cckControl.type} size={size}/>
-      )) }
+      {args.cckControl.themeComponentConfig.size?.values.map((size, index) => (
+        <Divider key={index} type={args.cckControl.type} size={size} />
+      ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/divider/divider/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/divider/divider/overview/type.stories.tsx
@@ -18,11 +18,17 @@ export const Type: StoryObj<typeof Divider> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <>
-              <% themeComponentConfig.type.values.map(type => { %>
-                <Divider type='<%= type %>'/>
-              <% }) %>
-            </>
+            import { Divider } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <% themeComponentConfig.type.values.map(type => { %>
+                    <Divider type='<%= type %>'/>
+                  <% }) %>
+                </>
+              );
+            }
           `,
         },
       ],
@@ -30,11 +36,20 @@ export const Type: StoryObj<typeof Divider> = {
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
-        <div key={index} style={{flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%', width: '100%'}}>
-          <Divider type={type}/>
+      {args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
+        <div
+          key={index}
+          style={{
+            flex: 1,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+            width: '100%',
+          }}>
+          <Divider type={type} />
         </div>
-      )) }
+      ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/form-field/chip-list/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/chip-list/overview/default.stories.tsx
@@ -18,19 +18,27 @@ export const Default: StoryObj<typeof ChipList> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField>
-              <Label><%= label %></Label>
-              <ChipList
-                chips={['Steak', 'Pizza']}
-                <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
-                <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
-                <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
-                <% if (disabled) { %> disabled <% } %>
-                placeholder="<%= placeholder %>"
-                addOnBlur={<%= addOnBlur %>}
-              >
-              </ChipList>
-            </FormField>
+            import { FormField, Label, ChipList } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <FormField>
+                    <Label><%= label %></Label>
+                    <ChipList
+                      chips={['Steak', 'Pizza']}
+                      <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
+                      <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
+                      <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
+                      <% if (disabled) { %> disabled <% } %>
+                      placeholder="<%= placeholder %>"
+                      addOnBlur={<%= addOnBlur %>}
+                    >
+                    </ChipList>
+                  </FormField>
+                </>
+              );
+            }
             `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/form-field/chip-list/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/chip-list/overview/size.stories.tsx
@@ -19,6 +19,10 @@ export const Size: StoryObj<typeof ChipList> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+          import { FormField, Label, ChipList } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
             <>
               <% themeComponentConfig.size.values.map(size => { %>
               
@@ -34,6 +38,8 @@ export const Size: StoryObj<typeof ChipList> = {
 
               <% }) %>
             </>
+              );
+            }
           `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/color.stories.tsx
@@ -19,16 +19,22 @@ export const Color: StoryObj<typeof Chip> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          <>
-            <% themeComponentConfig.color.values.map(color => { %>
-              <Chip
-                color="<%= color %>"
-                <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
-              >
-                Chip - <%= color %>
-              </Chip>
-            <% }) %>
-          </>
+            import { Chip } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <% themeComponentConfig.color.values.map(color => { %>
+                  <Chip
+                    color="<%= color %>"
+                    <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
+                  >
+                    Chip - <%= color %>
+                  </Chip>
+                  <% }) %>
+              </>
+              );
+            }
           `,
         },
       ],
@@ -43,5 +49,5 @@ export const Color: StoryObj<typeof Chip> = {
         </Chip>
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/default.stories.tsx
@@ -15,9 +15,14 @@ export const Default: StoryObj<typeof Chip> = {
       renderConditions: [renderWithPageTab('Overview')],
       source: [
         {
-          filename: 'example.component.html',
-          language: 'angular-html',
+          filename: 'Source Code',
+          language: 'tsx',
           code: `
+                     import { Chip } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <Chip
               <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
               <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
@@ -27,6 +32,10 @@ export const Default: StoryObj<typeof Chip> = {
               >
               <%= text %>
             </Chip>
+                </>
+              );
+            }
+
           `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/size.stories.tsx
@@ -19,16 +19,23 @@ export const Size: StoryObj<typeof Chip> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          <>
-            <% themeComponentConfig.size.values.map(size => { %>
-              <Chip
-                size="<%= size %>"
-                <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
-              >
-                Chip - <%= size %>
-              </Chip>
-            <% }) %>
-          </>
+            import { Chip } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <% themeComponentConfig.size.values.map(size => { %>
+                    <Chip
+                      size="<%= size %>"
+                      <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
+                    >
+                      Chip - <%= size %>
+                    </Chip>
+                  <% }) %>
+                </>
+              );
+            }
+
           `,
         },
       ],
@@ -37,9 +44,11 @@ export const Size: StoryObj<typeof Chip> = {
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.size?.values.map((size, index) => (
-        <Chip key={index} type={args.cckControl.type} size={size}>Chip - {size}</Chip>
-      )) }
+      {args.cckControl.themeComponentConfig.size?.values.map((size, index) => (
+        <Chip key={index} type={args.cckControl.type} size={size}>
+          Chip - {size}
+        </Chip>
+      ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/chip/overview/type.stories.tsx
@@ -18,11 +18,20 @@ export const Type: StoryObj<typeof Chip> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <% themeComponentConfig.type.values.map(type => { %>
-              <Chip type="<%= type %>">
-                Chip - <%= type %>
-              </Chip>
-            <% }) %>
+            import { Chip } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <% themeComponentConfig.type.values.map(type => { %>
+                    <Chip type="<%= type %>">
+                      Chip - <%= type %>
+                    </Chip>
+                  <% }) %>
+                </>
+              );
+            }
+
           `,
         },
       ],
@@ -30,9 +39,11 @@ export const Type: StoryObj<typeof Chip> = {
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
-        <Chip key={index} type={type}>Chip - {type}</Chip>
-      )) }
+      {args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
+        <Chip key={index} type={type}>
+          Chip - {type}
+        </Chip>
+      ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/chip-list.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/chip-list.stories.tsx
@@ -1,4 +1,15 @@
-import { ChipList as ChipListOriginal, Error, FormField, Hint, Label, Leading, Prefix, Suffix,SvgIcon, Trailing } from '@cocokits/react-components';
+import {
+  ChipList as ChipListOriginal,
+  Error,
+  FormField,
+  Hint,
+  Label,
+  Leading,
+  Prefix,
+  Suffix,
+  SvgIcon,
+  Trailing,
+} from '@cocokits/react-components';
 import { CCK_CONTROL, renderWithPageTab } from '@cocokits/storybook-addon-theme';
 import { reactThemeArgsToTemplate, StoryObj } from '@cocokits/storybook-addon-theme-react';
 
@@ -21,7 +32,12 @@ export const ChipList: StoryObj<typeof FormField> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField
+                     import { FormField, Label ,ChipListOriginal } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <FormField
               <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
               <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
               <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
@@ -66,6 +82,10 @@ export const ChipList: StoryObj<typeof FormField> = {
               <% } %>
 
             </FormField>
+                </>
+              );
+            }
+            
           `,
         },
       ],
@@ -99,38 +119,34 @@ export const ChipList: StoryObj<typeof FormField> = {
         disabled={args.cckControl.disabled}
         required={args.cckControl.required}
         invalid={args.cckControl.invalid}
-        hideRequiredMarker={args.cckControl.hideRequiredMarker}
-      >
-  
-        { args.cckControl.label && <Label>{args.cckControl.label}</Label> }
-        { args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading> }
-        {
-          args.cckControl.prefixIcon !== 'none' &&
+        hideRequiredMarker={args.cckControl.hideRequiredMarker}>
+        {args.cckControl.label && <Label>{args.cckControl.label}</Label>}
+        {args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading>}
+        {args.cckControl.prefixIcon !== 'none' && (
           <Prefix>
             <SvgIcon icon={args.cckIcons[args.cckControl.prefixIcon]} />
           </Prefix>
-        }
-  
+        )}
+
         <ChipListOriginal
           chips={['Steak', 'Pizza']}
           placeholder={args.cckControl.placeholder}
-          addOnBlur={args.cckControl.addOnBlur} />
-  
-        {
-          args.cckControl.suffixIcon !== 'none' &&
+          addOnBlur={args.cckControl.addOnBlur}
+        />
+
+        {args.cckControl.suffixIcon !== 'none' && (
           <Suffix>
             <SvgIcon icon={args.cckIcons[args.cckControl.suffixIcon]} />
           </Suffix>
-        }
-  
-        { args.cckControl.trailing && <Trailing>{args.cckControl.trailing}</Trailing> }
-  
-        { args.cckControl.hint && <Hint>{args.cckControl.hint}</Hint> }
-        { args.cckControl.error && <Error>{args.cckControl.error}</Error> }
-  
+        )}
+
+        {args.cckControl.trailing && <Trailing>{args.cckControl.trailing}</Trailing>}
+
+        {args.cckControl.hint && <Hint>{args.cckControl.hint}</Hint>}
+        {args.cckControl.error && <Error>{args.cckControl.error}</Error>}
       </FormField>
     );
-  }
+  },
   // render: (args) => ({
   //   props: {
   //     ...args,

--- a/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/input.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/input.stories.tsx
@@ -1,4 +1,14 @@
-import { Error,FormField, Hint, Input as InputOriginal, Label, Leading, Prefix, Suffix, Trailing } from '@cocokits/react-form-field';
+import {
+  Error,
+  FormField,
+  Hint,
+  Input as InputOriginal,
+  Label,
+  Leading,
+  Prefix,
+  Suffix,
+  Trailing,
+} from '@cocokits/react-form-field';
 import { SvgIcon } from '@cocokits/react-icon';
 import { CCK_CONTROL, renderWithPageTab } from '@cocokits/storybook-addon-theme';
 import { reactThemeArgsToTemplate, StoryObj } from '@cocokits/storybook-addon-theme-react';
@@ -19,50 +29,59 @@ export const Input: StoryObj<typeof FormField> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField
-              <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
-              <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
-              <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
-              <% if (disabled) { %> disabled <% } %>
-              <% if (required) { %> required <% } %>
-              <% if (invalid) { %> invalid <% } %>
-              <% if (hideRequiredMarker) { %> hideRequiredMarker <% } %>
-            >
+          import { FormField , Label , Input  } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+              <FormField
+                <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
+                <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
+                <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
+                <% if (disabled) { %> disabled <% } %>
+                <% if (required) { %> required <% } %>
+                <% if (invalid) { %> invalid <% } %>
+                <% if (hideRequiredMarker) { %> hideRequiredMarker <% } %>
+              >
 
-              <% if (label) { %>
-                <Label><%= label %></Label>
-              <% } %>
-              <% if (leading) { %>
-                <Leading><%= leading %></Leading>
-              <% } %>
-              <% if (prefixIcon !== 'none') { %>
-                <Prefix>
-                  <SvgIcon icon={YOUR_ICON} />
-                </Prefix>
-              <% } %>
+                <% if (label) { %>
+                  <Label><%= label %></Label>
+                <% } %>
+                <% if (leading) { %>
+                  <Leading><%= leading %></Leading>
+                <% } %>
+                <% if (prefixIcon !== 'none') { %>
+                  <Prefix>
+                    <SvgIcon icon={YOUR_ICON} />
+                  </Prefix>
+                <% } %>
 
-              <Input
-                <% if (placeholder) { %> placeholder="<%= placeholder %>" <% } %>
-              />
+                <Input
+                  <% if (placeholder) { %> placeholder="<%= placeholder %>" <% } %>
+                />
 
-               <% if (trailing) { %>
-                <Trailing><%= trailing %></Trailing>
-              <% } %>
-              <% if (suffixIcon !== 'none') { %>
-                <Suffix>
-                  <SvgIcon icon={YOUR_ICON} />
-                </Suffix>
-              <% } %>
+                <% if (trailing) { %>
+                  <Trailing><%= trailing %></Trailing>
+                <% } %>
+                <% if (suffixIcon !== 'none') { %>
+                  <Suffix>
+                    <SvgIcon icon={YOUR_ICON} />
+                  </Suffix>
+                <% } %>
 
-              <% if (hint) { %>
-                <Hint><%= hint %></Hint>
-              <% } %>
+                <% if (hint) { %>
+                  <Hint><%= hint %></Hint>
+                <% } %>
 
-              <% if (error) { %>
-                <Error><%= error %></Error>
-              <% } %>
+                <% if (error) { %>
+                  <Error><%= error %></Error>
+                <% } %>
 
-            </FormField>
+              </FormField>
+                </>
+              );
+            }
+            
           `,
         },
       ],
@@ -95,35 +114,28 @@ export const Input: StoryObj<typeof FormField> = {
         disabled={args.cckControl.disabled}
         required={args.cckControl.required}
         invalid={args.cckControl.invalid}
-        hideRequiredMarker={args.cckControl.hideRequiredMarker}
-      >
-  
-        { args.cckControl.label && <Label>{args.cckControl.label}</Label> }
-        { args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading> }
-        {
-          args.cckControl.prefixIcon !== 'none' &&
+        hideRequiredMarker={args.cckControl.hideRequiredMarker}>
+        {args.cckControl.label && <Label>{args.cckControl.label}</Label>}
+        {args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading>}
+        {args.cckControl.prefixIcon !== 'none' && (
           <Prefix>
             <SvgIcon icon={args.cckIcons[args.cckControl.prefixIcon]} />
           </Prefix>
-        }
-  
-        <InputOriginal placeholder={args.cckControl.placeholder}/>
-  
-        {
-          args.cckControl.suffixIcon !== 'none' &&
+        )}
+
+        <InputOriginal placeholder={args.cckControl.placeholder} />
+
+        {args.cckControl.suffixIcon !== 'none' && (
           <Suffix>
             <SvgIcon icon={args.cckIcons[args.cckControl.suffixIcon]} />
           </Suffix>
-        }
-  
-        { args.cckControl.trailing && <Trailing>{args.cckControl.trailing}</Trailing> }
-  
-        { args.cckControl.hint && <Hint>{args.cckControl.hint}</Hint> }
-        { args.cckControl.error && <Error>{args.cckControl.error}</Error> }
-  
+        )}
+
+        {args.cckControl.trailing && <Trailing>{args.cckControl.trailing}</Trailing>}
+
+        {args.cckControl.hint && <Hint>{args.cckControl.hint}</Hint>}
+        {args.cckControl.error && <Error>{args.cckControl.error}</Error>}
       </FormField>
     );
-  }
+  },
 };
-
-

--- a/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/select.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/select.stories.tsx
@@ -1,4 +1,15 @@
-import { Error, FormField, Hint, Label, Leading, Option, Prefix, Select as SelectOriginal, Suffix, Trailing } from '@cocokits/react-form-field';
+import {
+  Error,
+  FormField,
+  Hint,
+  Label,
+  Leading,
+  Option,
+  Prefix,
+  Select as SelectOriginal,
+  Suffix,
+  Trailing,
+} from '@cocokits/react-form-field';
 import { SvgIcon } from '@cocokits/react-icon';
 import { CCK_CONTROL, renderWithPageTab } from '@cocokits/storybook-addon-theme';
 import { reactThemeArgsToTemplate, StoryObj } from '@cocokits/storybook-addon-theme-react';
@@ -19,7 +30,13 @@ export const Select: StoryObj<typeof FormField> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField
+          
+           import { FormField, Label, Select , Option } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <FormField
               <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
               <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
               <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
@@ -69,6 +86,10 @@ export const Select: StoryObj<typeof FormField> = {
                   <Error><%= error %></Error>
               <% } %>
           </FormField>
+                </>
+              );
+            }
+            
           `,
         },
       ],
@@ -96,13 +117,12 @@ export const Select: StoryObj<typeof FormField> = {
   },
   render: (args) => (
     <FormField
-      style={{minWidth: '200px'}}
+      style={{ minWidth: '200px' }}
       {...reactThemeArgsToTemplate(args)}
       disabled={args.cckControl.disabled}
       required={args.cckControl.required}
       invalid={args.cckControl.invalid}
       hideRequiredMarker={args.cckControl.hideRequiredMarker}>
-
       {args.cckControl.label && <Label>{args.cckControl.label}</Label>}
       {args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading>}
       {args.cckControl.prefixIcon !== 'none' && (
@@ -111,9 +131,7 @@ export const Select: StoryObj<typeof FormField> = {
         </Prefix>
       )}
 
-      <SelectOriginal
-        placeholder={args.cckControl.placeholder}
-        multiple={args.cckControl.multiple}>
+      <SelectOriginal placeholder={args.cckControl.placeholder} multiple={args.cckControl.multiple}>
         <Option value="Steak">Steak</Option>
         <Option value="Pizza">Pizza</Option>
         <Option value="Burger">Burger</Option>

--- a/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/textarea.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/form-field/overview/textarea.stories.tsx
@@ -1,4 +1,14 @@
-import { Error,FormField, Hint, Label, Leading, Prefix, Suffix, Textarea as TextareaOriginal, Trailing } from '@cocokits/react-form-field';
+import {
+  Error,
+  FormField,
+  Hint,
+  Label,
+  Leading,
+  Prefix,
+  Suffix,
+  Textarea as TextareaOriginal,
+  Trailing,
+} from '@cocokits/react-form-field';
 import { SvgIcon } from '@cocokits/react-icon';
 import { CCK_CONTROL, renderWithPageTab } from '@cocokits/storybook-addon-theme';
 import { reactThemeArgsToTemplate, StoryObj } from '@cocokits/storybook-addon-theme-react';
@@ -19,7 +29,12 @@ export const Textarea: StoryObj<typeof FormField> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField
+                     import { FormField, Label, Textarea } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+                  <FormField
               <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
               <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
               <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
@@ -66,6 +81,10 @@ export const Textarea: StoryObj<typeof FormField> = {
               <% } %>
 
             </FormField>
+                </>
+              );
+            }
+            
           `,
         },
       ],
@@ -101,40 +120,33 @@ export const Textarea: StoryObj<typeof FormField> = {
         disabled={args.cckControl.disabled}
         required={args.cckControl.required}
         invalid={args.cckControl.invalid}
-        hideRequiredMarker={args.cckControl.hideRequiredMarker}
-      >
-  
-        { args.cckControl.label && <Label>{args.cckControl.label}</Label> }
-        { args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading> }
-        {
-          args.cckControl.prefixIcon !== 'none' &&
+        hideRequiredMarker={args.cckControl.hideRequiredMarker}>
+        {args.cckControl.label && <Label>{args.cckControl.label}</Label>}
+        {args.cckControl.leading && <Leading>{args.cckControl.leading}</Leading>}
+        {args.cckControl.prefixIcon !== 'none' && (
           <Prefix>
             <SvgIcon icon={args.cckIcons[args.cckControl.prefixIcon]} />
           </Prefix>
-        }
-  
+        )}
+
         <TextareaOriginal
           placeholder={args.cckControl.placeholder}
           autoResize={args.cckControl.autoResize}
           minRows={args.cckControl.minRows}
           maxRows={args.cckControl.maxRows}
         />
-  
-        {
-          args.cckControl.suffixIcon !== 'none' &&
+
+        {args.cckControl.suffixIcon !== 'none' && (
           <Suffix>
             <SvgIcon icon={args.cckIcons[args.cckControl.suffixIcon]} />
           </Suffix>
-        }
-  
-        { args.cckControl.trailing && <Trailing>{args.cckControl.trailing}</Trailing> }
-  
-        { args.cckControl.hint && <Hint>{args.cckControl.hint}</Hint> }
-        { args.cckControl.error && <Error>{args.cckControl.error}</Error> }
-  
+        )}
+
+        {args.cckControl.trailing && <Trailing>{args.cckControl.trailing}</Trailing>}
+
+        {args.cckControl.hint && <Hint>{args.cckControl.hint}</Hint>}
+        {args.cckControl.error && <Error>{args.cckControl.error}</Error>}
       </FormField>
     );
-  }
+  },
 };
-
-

--- a/apps/react-kits-doc/stories/ui-components/form-field/input/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/input/overview/default.stories.tsx
@@ -18,6 +18,11 @@ export const Default: StoryObj<typeof Input> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { FormField, Label , Input } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
           <FormField>
             <% if (label) { %>
               <Label><%= label %></Label>
@@ -32,6 +37,10 @@ export const Default: StoryObj<typeof Input> = {
               <% if (placeholder) { %> placeholder="<%= placeholder %>" <% } %>
             />
           </FormField>
+                </>
+              );
+            }
+
             `,
         },
       ],
@@ -51,7 +60,7 @@ export const Default: StoryObj<typeof Input> = {
   },
   render: (args) => (
     <FormField style={{ minWidth: '200px' }}>
-      {args.cckControl.label && <Label>{args.cckControl.label}</Label> }
+      {args.cckControl.label && <Label>{args.cckControl.label}</Label>}
       <Input
         {...reactThemeArgsToTemplate(args)}
         placeholder={args.cckControl.placeholder}
@@ -60,5 +69,5 @@ export const Default: StoryObj<typeof Input> = {
         invalid={args.cckControl.invalid}
       />
     </FormField>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/form-field/select/overview/custom-preview.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/select/overview/custom-preview.stories.tsx
@@ -18,7 +18,12 @@ export const CustomPreview: StoryObj<typeof Select> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField>
+                     import { FormField, Label, Option, Select } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+      <FormField>
                <% if (label) { %>
                 <Label><%= label %></Label>
               <% } %>
@@ -47,6 +52,10 @@ export const CustomPreview: StoryObj<typeof Select> = {
 
               </Select>
             </FormField>
+                </>
+              );
+            }
+      
             `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/form-field/select/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/select/overview/default.stories.tsx
@@ -19,6 +19,11 @@ export const Default: StoryObj<typeof Select> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { FormField, Label, Option, Select } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <FormField>
                <% if (label) { %>
                 <Label><%= label %></Label>
@@ -40,6 +45,10 @@ export const Default: StoryObj<typeof Select> = {
                 <Option value="Burger">Burger</Option>
               </Select>
             </FormField>
+                </>
+              );
+            }
+
             `,
         },
       ],
@@ -71,8 +80,7 @@ export const Default: StoryObj<typeof Select> = {
         invalid={args.cckControl.invalid}
         multiple={args.cckControl.multiple}
         anchorPoint={args.cckControl.anchorPoint}
-        maxOptionsHeight={args.cckControl.maxOptionsHeight}
-      >
+        maxOptionsHeight={args.cckControl.maxOptionsHeight}>
         <Option value="Steak">Steak</Option>
         <Option value="Pizza">Pizza</Option>
         <Option value="Burger">Burger</Option>

--- a/apps/react-kits-doc/stories/ui-components/form-field/select/overview/options.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/select/overview/options.stories.tsx
@@ -18,6 +18,11 @@ export const Options: StoryObj<typeof Select> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { FormField, Label, Option, OptionGroup, Select } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <FormField>
                <% if (label) { %>
                 <Label><%= label %></Label>
@@ -50,6 +55,10 @@ export const Options: StoryObj<typeof Select> = {
 
               </Select>
             </FormField>
+                </>
+              );
+            }
+
             `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/form-field/textarea/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/form-field/textarea/overview/default.stories.tsx
@@ -18,7 +18,12 @@ export const Default: StoryObj<typeof Textarea> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            <FormField>
+                     import { FormField, Label, Textarea } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
+<FormField>
               <% if (label) { %>
                 <Label><%= label %></Label>
               <% } %>
@@ -36,6 +41,10 @@ export const Default: StoryObj<typeof Textarea> = {
                 <% if (typeof maxRows !== 'undefined') { %> maxRows={<%= maxRows %>} <% } %>
               />
             </FormField>
+                </>
+              );
+            }
+            
           `,
         },
       ],
@@ -58,7 +67,7 @@ export const Default: StoryObj<typeof Textarea> = {
   },
   render: (args) => (
     <FormField>
-      {args.cckControl.label && <Label>{args.cckControl.label}</Label> }
+      {args.cckControl.label && <Label>{args.cckControl.label}</Label>}
       <Textarea
         {...reactThemeArgsToTemplate(args)}
         placeholder={args.cckControl.placeholder}
@@ -70,5 +79,5 @@ export const Default: StoryObj<typeof Textarea> = {
         maxRows={args.cckControl.maxRows}
       />
     </FormField>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/color.stories.tsx
@@ -18,7 +18,7 @@ export const Color: StoryObj<typeof SvgIcon> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            import { Checkbox } from "@cocokits/react-components";
+            import { SvgIcon } from "@cocokits/react-components";
   
             export const MyComponent = () => {
               return (
@@ -42,7 +42,7 @@ export const Color: StoryObj<typeof SvgIcon> = {
   render: (args) => (
     <>
       {args.cckControl.themeComponentConfig.color?.values.map((color, index) => (
-        <SvgIcon key={index} type={args.cckControl.type} color={color} icon={args.cckIcons.heartFill}/>
+        <SvgIcon key={index} type={args.cckControl.type} color={color} icon={args.cckIcons.heartFill} />
       ))}
     </>
   ),

--- a/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/default.stories.tsx
@@ -18,27 +18,27 @@ export const Default: StoryObj<typeof SvgIcon> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { SvgIcon } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <SvgIcon
               <% if (typeof type !== 'undefined') { %> type="<%= type %>" <% } %>
               <% if (typeof size !== 'undefined') { %> size="<%= size %>" <% } %>
               <% if (typeof color !== 'undefined') { %> color="<%= color %>" <% } %>
               icon={YOUR_ICON}
             />
+                </>
+              );
+            }
+
           `,
         },
       ],
       hasControl: true,
-      controls: [
-        CCK_CONTROL.icon('heartFill'),
-        CCK_CONTROL.type(),
-        CCK_CONTROL.color(),
-        CCK_CONTROL.size(),
-      ],
+      controls: [CCK_CONTROL.icon('heartFill'), CCK_CONTROL.type(), CCK_CONTROL.color(), CCK_CONTROL.size()],
     },
   },
-  render: (args) => (
-    <SvgIcon
-      {...reactThemeArgsToTemplate(args)}
-      icon={args.cckIcons[args.cckControl.icon]}/>
-  )
+  render: (args) => <SvgIcon {...reactThemeArgsToTemplate(args)} icon={args.cckIcons[args.cckControl.icon]} />,
 };

--- a/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/size.stories.tsx
@@ -19,7 +19,7 @@ export const Size: StoryObj<typeof SvgIcon> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            import { Checkbox } from "@cocokits/react-components";
+            import { SvgIcon } from "@cocokits/react-components";
   
             export const MyComponent = () => {
               return (
@@ -43,8 +43,8 @@ export const Size: StoryObj<typeof SvgIcon> = {
   render: (args) => (
     <>
       {args.cckControl.themeComponentConfig.size?.values.map((size, index) => (
-        <SvgIcon key={index} type={args.cckControl.type} size={size} icon={args.cckIcons.heartFill}/>
+        <SvgIcon key={index} type={args.cckControl.type} size={size} icon={args.cckIcons.heartFill} />
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/icon/svg-icon/overview/type.stories.tsx
@@ -7,7 +7,8 @@ export const Type: StoryObj<typeof SvgIcon> = {
   parameters: {
     docs: {
       description: {
-        story: 'Displays variations in appearance and functionality, demonstrating how different types can be used to create unique button styles.',
+        story:
+          'Displays variations in appearance and functionality, demonstrating how different types can be used to create unique button styles.',
       },
     },
     cckAddon: {
@@ -17,7 +18,7 @@ export const Type: StoryObj<typeof SvgIcon> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { Button } from "@cocokits/react-components";
+          import { SvgIcon } from "@cocokits/react-components";
 
           export const MyComponent = () => {
             return (
@@ -38,9 +39,9 @@ export const Type: StoryObj<typeof SvgIcon> = {
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
-        <SvgIcon key={index} type={type} icon={args.cckIcons.heartFill}/>
-      )) }
+      {args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
+        <SvgIcon key={index} type={type} icon={args.cckIcons.heartFill} />
+      ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/menu/menu/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/menu/menu/overview/color.stories.tsx
@@ -18,6 +18,10 @@ export const Color: StoryObj<typeof Menu> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { Divider, Menu, MenuItem } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
           <>
             <% themeComponentConfig.color.values.map(color => { %>
 
@@ -35,6 +39,9 @@ export const Color: StoryObj<typeof Menu> = {
 
             <% }) %>
           </>
+              );
+            }
+
           `,
         },
       ],
@@ -47,12 +54,11 @@ export const Color: StoryObj<typeof Menu> = {
         <Menu key={index} type={args.cckControl.type} color={color} open={true} _skipOverlay={true}>
           <MenuItem>Edit</MenuItem>
           <MenuItem>Duplicate</MenuItem>
-          <Divider/>
+          <Divider />
           <MenuItem>Archive</MenuItem>
           <MenuItem>Move</MenuItem>
         </Menu>
       ))}
     </>
-  )
+  ),
 };
-

--- a/apps/react-kits-doc/stories/ui-components/menu/menu/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/menu/menu/overview/default.stories.tsx
@@ -20,7 +20,7 @@ export const Default: StoryObj<typeof Menu> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { Button, SvgIcon } from "@cocokits/react-components";
+          import { Button , Menu, MenuItem  , Divider} from "@cocokits/react-components";
 
           export const MyComponent = () => {
             const buttonRef = useRef<HTMLButtonElement>(null);

--- a/apps/react-kits-doc/stories/ui-components/menu/menu/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/menu/menu/overview/size.stories.tsx
@@ -18,6 +18,10 @@ export const Size: StoryObj<typeof Menu> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { Menu, MenuItem , Divider } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
             <>
 
               <% themeComponentConfig.size.values.map(size => { %>
@@ -36,6 +40,9 @@ export const Size: StoryObj<typeof Menu> = {
               <% }) %>
 
             </>
+              );
+            }
+
           `,
         },
       ],
@@ -48,12 +55,11 @@ export const Size: StoryObj<typeof Menu> = {
         <Menu key={index} type={args.cckControl.type} size={size} open={true} _skipOverlay={true}>
           <MenuItem>Edit</MenuItem>
           <MenuItem>Duplicate</MenuItem>
-          <Divider/>
+          <Divider />
           <MenuItem>Archive</MenuItem>
           <MenuItem>Move</MenuItem>
         </Menu>
       ))}
     </>
-  )
+  ),
 };
-

--- a/apps/react-kits-doc/stories/ui-components/menu/menu/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/menu/menu/overview/type.stories.tsx
@@ -18,6 +18,10 @@ export const Type: StoryObj<typeof Menu> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { Divider , Menu, MenuItem } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
             <>
               <% themeComponentConfig.type.values.map(type => { %>
 
@@ -32,6 +36,9 @@ export const Type: StoryObj<typeof Menu> = {
               <% }) %>
               
             </>
+              );
+            }
+
           `,
         },
       ],
@@ -43,11 +50,11 @@ export const Type: StoryObj<typeof Menu> = {
         <Menu key={index} type={type} open={true}>
           <MenuItem>Edit</MenuItem>
           <MenuItem>Duplicate</MenuItem>
-          <Divider/>
+          <Divider />
           <MenuItem>Archive</MenuItem>
           <MenuItem>Move</MenuItem>
         </Menu>
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/color.stories.tsx
@@ -18,6 +18,10 @@ export const Color: StoryObj<typeof RadioButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
           <>
             <% themeComponentConfig.color.values.map((color, index) => { %>
 
@@ -30,6 +34,9 @@ export const Color: StoryObj<typeof RadioButton> = {
               </RadioButton>
             <% }) %>
           </>
+              );
+            }
+
           `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/default.stories.tsx
@@ -18,6 +18,11 @@ export const Default: StoryObj<typeof RadioButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <RadioButton
               <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
               <% if (typeof color !== 'undefined') { %> color='<%= color %>' <% } %>
@@ -28,6 +33,10 @@ export const Default: StoryObj<typeof RadioButton> = {
               >
               <%= text %>
             </RadioButton>
+                </>
+              );
+            }
+
           `,
         },
       ],
@@ -53,5 +62,5 @@ export const Default: StoryObj<typeof RadioButton> = {
         {args.cckControl.text}
       </RadioButton>
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/size.stories.tsx
@@ -1,5 +1,5 @@
 import { RadioButton } from '@cocokits/react-components';
-import { AddonParametersControlType, CCK_CONTROL, renderWithPageTab, renderWithThemeProp } from '@cocokits/storybook-addon-theme';
+import { CCK_CONTROL, renderWithPageTab, renderWithThemeProp } from '@cocokits/storybook-addon-theme';
 import { StoryObj } from '@cocokits/storybook-addon-theme-react';
 
 export const Size: StoryObj<typeof RadioButton> = {
@@ -19,6 +19,10 @@ export const Size: StoryObj<typeof RadioButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
           <>
             <% themeComponentConfig.size.values.map((size, index) => { %>
 
@@ -31,6 +35,9 @@ export const Size: StoryObj<typeof RadioButton> = {
               </RadioButton>
             <% }) %>
           </>
+              );
+            }
+
           `,
         },
       ],
@@ -45,5 +52,5 @@ export const Size: StoryObj<typeof RadioButton> = {
         </RadioButton>
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-button/overview/type.stories.tsx
@@ -18,11 +18,20 @@ export const Type: StoryObj<typeof RadioButton> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
           <% themeComponentConfig.type.values.map(type => { %>
             <RadioButton type='<%= type %>' value='YOUR_VALUE'>
               Radio Button - {type}
             </RadioButton>
           <% }) %>
+                </>
+              );
+            }
+
           `,
         },
       ],
@@ -36,5 +45,5 @@ export const Type: StoryObj<typeof RadioButton> = {
         </RadioButton>
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/color.stories.tsx
@@ -18,6 +18,10 @@ export const Color: StoryObj<typeof RadioGroup> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton, RadioGroup } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
           <>
             <% themeComponentConfig.color.values.map(color => { %>
 
@@ -30,6 +34,9 @@ export const Color: StoryObj<typeof RadioGroup> = {
               </RadioGroup>
             <% }) %>
           </>
+              );
+            }
+
           `,
         },
       ],
@@ -46,5 +53,5 @@ export const Color: StoryObj<typeof RadioGroup> = {
         </RadioGroup>
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/default.stories.tsx
@@ -18,6 +18,11 @@ export const Default: StoryObj<typeof RadioGroup> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton, RadioGroup } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <RadioGroup
               <% if (typeof type !== 'undefined') { %> type='<%= type %>' <% } %>
               <% if (typeof size !== 'undefined') { %> size='<%= size %>' <% } %>
@@ -28,6 +33,10 @@ export const Default: StoryObj<typeof RadioGroup> = {
               <RadioButton value="Radio-2">Radio Button 2</RadioButton>
               <RadioButton value="Radio-3">Radio Button 3</RadioButton>
             </RadioGroup>
+                </>
+              );
+            }
+
           `,
         },
       ],
@@ -51,5 +60,5 @@ export const Default: StoryObj<typeof RadioGroup> = {
       <RadioButton value="Radio-2">Radio Button 2</RadioButton>
       <RadioButton value="Radio-3">Radio Button 3</RadioButton>
     </RadioGroup>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/size.stories.tsx
@@ -19,6 +19,10 @@ export const Size: StoryObj<typeof RadioGroup> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton, RadioGroup } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
           <>
             <% themeComponentConfig.size.values.map(size => { %>
 
@@ -31,6 +35,9 @@ export const Size: StoryObj<typeof RadioGroup> = {
               </RadioGroup>
             <% }) %>
           </>
+              );
+            }
+
           `,
         },
       ],

--- a/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/radio/radio-group/overview/type.stories.tsx
@@ -18,6 +18,10 @@ export const Type: StoryObj<typeof RadioGroup> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { RadioButton, RadioGroup } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
             <>
               <% themeComponentConfig.type.values.map(type => { %>
                 <RadioGroup type="<%= type %>">
@@ -27,6 +31,9 @@ export const Type: StoryObj<typeof RadioGroup> = {
                 </RadioGroup>
               <% }) %>
             </>
+              );
+            }
+
           `,
         },
       ],
@@ -42,5 +49,5 @@ export const Type: StoryObj<typeof RadioGroup> = {
         </RadioGroup>
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/color.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/color.stories.tsx
@@ -18,7 +18,7 @@ export const Color: StoryObj<typeof Toggle> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            import { Checkbox } from "@cocokits/react-components";
+            import { Toggle } from "@cocokits/react-components";
   
             export const MyComponent = () => {
               return (
@@ -41,7 +41,7 @@ export const Color: StoryObj<typeof Toggle> = {
   render: (args) => (
     <>
       {args.cckControl.themeComponentConfig.color?.values.map((color, index) => (
-        <Toggle key={index} type={args.cckControl.type} color={color} checked/>
+        <Toggle key={index} type={args.cckControl.type} color={color} checked />
       ))}
     </>
   ),

--- a/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/default.stories.tsx
@@ -18,6 +18,11 @@ export const Default: StoryObj<typeof Toggle> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
+                     import { Toggle } from "@cocokits/react-components";
+  
+            export const MyComponent = () => {
+              return (
+                <>
             <Toggle
               <% if (typeof type !== 'undefined') { %> type="<%= type %>" <% } %>
               <% if (typeof size !== 'undefined') { %> size="<%= size %>" <% } %>
@@ -28,6 +33,10 @@ export const Default: StoryObj<typeof Toggle> = {
             >
               <%= text %>
             </Toggle>
+                </>
+              );
+            }
+
           `,
         },
       ],
@@ -52,5 +61,5 @@ export const Default: StoryObj<typeof Toggle> = {
       labelPosition={args.cckControl.labelPosition}>
       {args.cckControl.text}
     </Toggle>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/size.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/size.stories.tsx
@@ -19,7 +19,7 @@ export const Size: StoryObj<typeof Toggle> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-            import { Checkbox } from "@cocokits/react-components";
+            import { Toggle } from "@cocokits/react-components";
   
             export const MyComponent = () => {
               return (
@@ -42,8 +42,8 @@ export const Size: StoryObj<typeof Toggle> = {
   render: (args) => (
     <>
       {args.cckControl.themeComponentConfig.size?.values.map((size, index) => (
-        <Toggle key={index} type={args.cckControl.type} size={size}/>
+        <Toggle key={index} type={args.cckControl.type} size={size} />
       ))}
     </>
-  )
+  ),
 };

--- a/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/type.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/toggle/toggle/overview/type.stories.tsx
@@ -7,7 +7,8 @@ export const Type: StoryObj<typeof Toggle> = {
   parameters: {
     docs: {
       description: {
-        story: 'Displays variations in appearance and functionality, demonstrating how different types can be used to create unique button styles.',
+        story:
+          'Displays variations in appearance and functionality, demonstrating how different types can be used to create unique button styles.',
       },
     },
     cckAddon: {
@@ -17,7 +18,7 @@ export const Type: StoryObj<typeof Toggle> = {
           filename: 'Source Code',
           language: 'tsx',
           code: `
-          import { Button } from "@cocokits/react-components";
+          import { Toggle } from "@cocokits/react-components";
 
           export const MyComponent = () => {
             return (
@@ -39,9 +40,11 @@ export const Type: StoryObj<typeof Toggle> = {
   },
   render: (args) => (
     <>
-      { args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
-        <Toggle key={index} type={type}>{type}</Toggle>
-      )) }
+      {args.cckControl.themeComponentConfig.type?.values.map((type, index) => (
+        <Toggle key={index} type={type}>
+          {type}
+        </Toggle>
+      ))}
     </>
-  )
+  ),
 };


### PR DESCRIPTION
This PR improves the documentation for React components by adding missing import statements in story source code examples. These changes enhance clarity and ensure that users can easily copy and use the examples without confusion.

### Changes:
Added import statements for `Button`, `IconButton`, `Checkbox`, `Divider`, `ChipList`, `Menu`, and other components.
Wrapped example code in proper React component structure.
Fixed incorrect component names in import statements.
Ensured consistent formatting across examples.
Let me know if any further adjustments are needed. 🚀