### PR TITLE
fix(docs): add missing label to checkbox example in storybook

### DIFF
--- a/apps/react-kits-doc/stories/ui-components/checkbox/checkbox/overview/default.stories.tsx
+++ b/apps/react-kits-doc/stories/ui-components/checkbox/checkbox/overview/default.stories.tsx
@@ -32,7 +32,9 @@ export const Default: StoryObj<typeof Checkbox> = {
                       <% if (disabled) { %> disabled <% } %>
                       <% if (checked) { %> checked <% } %>
                       value="YOUR_VALUE"
-                    />
+                    >
+                       Checkbox Label
+                    </Checkbox>
                 </>
               );
             }


### PR DESCRIPTION
Complete `Checkbox`tag by adding a label in the Storybook example.






