### PR TITLE
fix(docs): correct theme configuration examples and SCSS syntax

### DIFF
--- a/apps/react-kits-doc/stories/getting-started/advanced-configuration.mdx
+++ b/apps/react-kits-doc/stories/getting-started/advanced-configuration.mdx
@@ -142,10 +142,10 @@ import { framesXThemeConfig } from '@cocokits/theme-frames-x';
 
 const customThemeConfig = deepMerge(cocokitsThemeConfig, {
   components: {
-    button: framesXThemeConfig.button,
-    iconButton: framesXThemeConfig.iconButton,
-    radioGroup: framesXThemeConfig.radioGroup,
-    radioButton: framesXThemeConfig.radioButton,
+    button: framesXThemeConfig.components.button,
+    iconButton: framesXThemeConfig.components.iconButton,
+    radioGroup: framesXThemeConfig.components.radioGroup,
+    radioButton: framesXThemeConfig.components.radioButton,
   }
 } as DeepPartial<ThemeConfig>);
 

--- a/apps/react-kits-doc/stories/getting-started/utils/advanced-configuration.utils.tsx
+++ b/apps/react-kits-doc/stories/getting-started/utils/advanced-configuration.utils.tsx
@@ -21,7 +21,7 @@ export const tocItems = [
 export function getUseOnlyOneModeOption1Step1Code(theme: ThemeChangeEvent) {
 
   const mixinNames = Object.entries(theme.selectedModes)
-    .map(([collection, mode]) => `@include ${toTitleCase(theme.displayName)}.use_${collection}_${mode}`);
+    .map(([collection, mode]) => `@include ${toTitleCase(theme.displayName)}.use_${collection}_${mode};`);
 
   const scss = `scss
 @use "@cocokits/theme-${theme.id}/tokens-core" as ${toTitleCase(theme.displayName)};
@@ -62,7 +62,7 @@ export function getUseOnlyOneModeOption1Step2AttrSelector(theme: ThemeChangeEven
 
 export function getUseOnlyOneModeOption1code(theme: ThemeChangeEvent) {
   const mixinNames = Object.entries(theme.selectedModes)
-    .map(([collection, mode]) => `@include ${toTitleCase(theme.displayName)}.variables_${collection}_${mode}`);
+    .map(([collection, mode]) => `@include ${toTitleCase(theme.displayName)}.variables_${collection}_${mode};`);
 
   const scss = `scss
 @use "@cocokits/theme-${theme.id}/tokens-core" as ${toTitleCase(theme.displayName)};
@@ -95,7 +95,7 @@ export function getChangeTokenSelectorsStep1Code(theme: ThemeChangeEvent) {
 
   const otherMixins = Object.entries(theme.selectedModes)
     .filter(([collection]) => collection !== collectionNameWithLightAndDark)
-    .map(([collection, mode]) => `@include ${toTitleCase(theme.displayname)}.variables_${collection}_${mode}`);
+    .map(([collection, mode]) => `@include ${toTitleCase(theme.displayname)}.variables_${collection}_${mode};`);
 
   const scss = `scss
 @use "@cocokits/theme-${theme.id}/tokens-core" as ${toTitleCase(theme.displayname)};


### PR DESCRIPTION
- Fix component access paths in framesXThemeConfig example
- Add missing semicolons to SCSS @include statements
- Ensure consistent formatting across all theme configuration examples